### PR TITLE
Resolve #12 "Replace the Task array with a priority queue"

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -2,42 +2,36 @@ package scheduledworker
 
 import (
 	"container/heap"
-	"time"
 )
 
 type Queue interface {
-	Push(*Item)
-	Pop() *Item
+	Push(*Task)
+	Pop() *Task
 	Len() int
-	Peek() *Item
+	Peek() *Task
 }
 
-type Item struct {
-	task     Task
-	priority time.Time
-}
-
-type items []*Item
+type queue []*Task
 
 type PriorityQueue struct {
-	queue items
+	queue queue
 }
 
 func NewPriorityQueue() *PriorityQueue {
-	q := make(items, 0)
+	q := make(queue, 0)
 	heap.Init(&q)
 	return &PriorityQueue{queue: q}
 }
 
-func (pq *PriorityQueue) Push(x *Item) {
+func (pq *PriorityQueue) Push(x *Task) {
 	heap.Push(&pq.queue, x)
 }
 
-func (pq *PriorityQueue) Pop() *Item {
-	return heap.Pop(&pq.queue).(*Item)
+func (pq *PriorityQueue) Pop() *Task {
+	return heap.Pop(&pq.queue).(*Task)
 }
 
-func (pq *PriorityQueue) Peek() *Item {
+func (pq *PriorityQueue) Peek() *Task {
 	if len(pq.queue) == 0 {
 		return nil
 	}
@@ -48,22 +42,22 @@ func (pq *PriorityQueue) Len() int {
 	return pq.queue.Len()
 }
 
-func (pq *items) Len() int { return len(*pq) }
+func (pq *queue) Len() int { return len(*pq) }
 
-func (pq *items) Less(i, j int) bool {
-	return (*pq)[i].priority.Before((*pq)[j].priority)
+func (pq *queue) Less(i, j int) bool {
+	return (*pq)[i].At.Before((*pq)[j].At)
 }
 
-func (pq *items) Swap(i, j int) {
+func (pq *queue) Swap(i, j int) {
 	(*pq)[i], (*pq)[j] = (*pq)[j], (*pq)[i]
 }
 
-func (pq *items) Push(x interface{}) {
-	item := x.(*Item)
+func (pq *queue) Push(x interface{}) {
+	item := x.(*Task)
 	*pq = append(*pq, item)
 }
 
-func (pq *items) Pop() interface{} {
+func (pq *queue) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]

--- a/queue.go
+++ b/queue.go
@@ -17,6 +17,9 @@ type PriorityQueue struct {
 	queue queue
 }
 
+var _ Queue = &PriorityQueue{}
+var _ heap.Interface = &queue{}
+
 func NewPriorityQueue() *PriorityQueue {
 	q := make(queue, 0)
 	heap.Init(&q)

--- a/queue.go
+++ b/queue.go
@@ -5,48 +5,69 @@ import (
 	"time"
 )
 
+type Queue interface {
+	Push(*Item)
+	Pop() *Item
+	Len() int
+	Peek() *Item
+}
+
 type Item struct {
 	task     Task
 	priority time.Time
 }
 
-type PriorityQueue []*Item
+type items []*Item
 
-func (pq *PriorityQueue) Len() int { return len(*pq) }
+type PriorityQueue struct {
+	queue items
+}
 
-func (pq *PriorityQueue) Less(i, j int) bool {
+func NewPriorityQueue() *PriorityQueue {
+	q := make(items, 0)
+	heap.Init(&q)
+	return &PriorityQueue{queue: q}
+}
+
+func (pq *PriorityQueue) Push(x *Item) {
+	heap.Push(&pq.queue, x)
+}
+
+func (pq *PriorityQueue) Pop() *Item {
+	return heap.Pop(&pq.queue).(*Item)
+}
+
+func (pq *PriorityQueue) Peek() *Item {
+	if len(pq.queue) == 0 {
+		return nil
+	}
+	return (pq.queue)[0]
+}
+
+func (pq *PriorityQueue) Len() int {
+	return pq.queue.Len()
+}
+
+func (pq *items) Len() int { return len(*pq) }
+
+func (pq *items) Less(i, j int) bool {
 	return (*pq)[i].priority.Before((*pq)[j].priority)
 }
 
-func (pq *PriorityQueue) Swap(i, j int) {
+func (pq *items) Swap(i, j int) {
 	(*pq)[i], (*pq)[j] = (*pq)[j], (*pq)[i]
 }
 
-func (pq *PriorityQueue) PushItem(x *Item) {
-	heap.Push(pq, x)
-}
-
-func (pq *PriorityQueue) PopItem() *Item {
-	return heap.Pop(pq).(*Item)
-}
-
-func (pq *PriorityQueue) Push(x interface{}) {
+func (pq *items) Push(x interface{}) {
 	item := x.(*Item)
 	*pq = append(*pq, item)
 }
 
-func (pq *PriorityQueue) Pop() interface{} {
+func (pq *items) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil // avoid memory leak
+	old[n-1] = nil
 	*pq = old[:n-1]
 	return item
-}
-
-func (pq *PriorityQueue) Peek() *Item {
-	if len(*pq) == 0 {
-		return nil
-	}
-	return (*pq)[0]
 }

--- a/queue.go
+++ b/queue.go
@@ -7,31 +7,34 @@ import (
 
 type Item struct {
 	task     Task
-	priority time.Time // The priority of the item in the queue.
-	// The index is needed by update and is maintained by the heap.Interface methods.
-	index int // The index of the item in the heap.
+	priority time.Time
+	index    int // needed for container/heap functions
 }
 
-// A PriorityQueue implements heap.Interface and holds Items.
 type PriorityQueue []*Item
 
-func (pq PriorityQueue) Len() int { return len(pq) }
+func (pq *PriorityQueue) Len() int { return len(*pq) }
 
-func (pq PriorityQueue) Less(i, j int) bool {
-	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
-	return pq[i].priority.Before(pq[j].priority)
+func (pq *PriorityQueue) Less(i, j int) bool {
+	return (*pq)[i].priority.Before((*pq)[j].priority)
 }
 
-func (pq PriorityQueue) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index = i
-	pq[j].index = j
+func (pq *PriorityQueue) Swap(i, j int) {
+	(*pq)[i], (*pq)[j] = (*pq)[j], (*pq)[i]
+	(*pq)[i].index = i
+	(*pq)[j].index = j
+}
+
+func (pq *PriorityQueue) PushItem(x *Item) {
+	heap.Push(pq, x)
+}
+
+func (pq *PriorityQueue) PopItem() *Item {
+	return heap.Pop(pq).(*Item)
 }
 
 func (pq *PriorityQueue) Push(x interface{}) {
-	n := len(*pq)
 	item := x.(*Item)
-	item.index = n
 	*pq = append(*pq, item)
 }
 
@@ -39,22 +42,14 @@ func (pq *PriorityQueue) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil
-	item.index = -1
-	*pq = old[0 : n-1]
+	old[n-1] = nil // avoid memory leak
+	*pq = old[:n-1]
 	return item
 }
 
-func (pq PriorityQueue) Peek() *Item {
-	if len(pq) == 0 {
+func (pq *PriorityQueue) Peek() *Item {
+	if len(*pq) == 0 {
 		return nil
 	}
-	return pq[0]
-}
-
-// update modifies the priority and value of an Item in the queue.
-func (pq *PriorityQueue) update(item *Item, task Task, priority time.Time) {
-	item.task = task
-	item.priority = priority
-	heap.Fix(pq, item.index)
+	return (*pq)[0]
 }

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,60 @@
+package scheduledworker
+
+import (
+	"container/heap"
+	"time"
+)
+
+type Item struct {
+	task     Task
+	priority time.Time // The priority of the item in the queue.
+	// The index is needed by update and is maintained by the heap.Interface methods.
+	index int // The index of the item in the heap.
+}
+
+// A PriorityQueue implements heap.Interface and holds Items.
+type PriorityQueue []*Item
+
+func (pq PriorityQueue) Len() int { return len(pq) }
+
+func (pq PriorityQueue) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].priority.Before(pq[j].priority)
+}
+
+func (pq PriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *PriorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*Item)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*pq = old[0 : n-1]
+	return item
+}
+
+func (pq PriorityQueue) Peek() *Item {
+	if len(pq) == 0 {
+		return nil
+	}
+	return pq[0]
+}
+
+// update modifies the priority and value of an Item in the queue.
+func (pq *PriorityQueue) update(item *Item, task Task, priority time.Time) {
+	item.task = task
+	item.priority = priority
+	heap.Fix(pq, item.index)
+}

--- a/queue.go
+++ b/queue.go
@@ -8,7 +8,6 @@ import (
 type Item struct {
 	task     Task
 	priority time.Time
-	index    int // needed for container/heap functions
 }
 
 type PriorityQueue []*Item
@@ -21,8 +20,6 @@ func (pq *PriorityQueue) Less(i, j int) bool {
 
 func (pq *PriorityQueue) Swap(i, j int) {
 	(*pq)[i], (*pq)[j] = (*pq)[j], (*pq)[i]
-	(*pq)[i].index = i
-	(*pq)[j].index = j
 }
 
 func (pq *PriorityQueue) PushItem(x *Item) {

--- a/queue.go
+++ b/queue.go
@@ -38,7 +38,7 @@ func (pq *PriorityQueue) Peek() *Task {
 	if len(pq.queue) == 0 {
 		return nil
 	}
-	return (pq.queue)[0]
+	return pq.queue[0]
 }
 
 func (pq *PriorityQueue) Len() int {

--- a/queue_test.go
+++ b/queue_test.go
@@ -55,7 +55,7 @@ func TestPriorityQueue(t *testing.T) {
 		l := pq.Len()
 		item := pq.Pop()
 		if item.At != newItem.At {
-			t.Errorf("item.priority = %v, want %v", item.At, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+			t.Errorf("item.priority = %v, want %v", item.At, newItem.At)
 		}
 		if pq.Len() != l-1 {
 			t.Errorf("pq.Len() = %d, want %d", pq.Len(), 3)
@@ -66,7 +66,7 @@ func TestPriorityQueue(t *testing.T) {
 		l := pq.Len()
 		item := pq.Peek()
 		if item.At != pq.queue[0].At {
-			t.Errorf("item.priority = %v, want %v", item.At, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+			t.Errorf("item.priority = %v, want %v", item.At, pq.queue[0].At)
 		}
 		if pq.Len() != l {
 			t.Errorf("pq.Len() = %d, want %d", pq.Len(), 3)

--- a/queue_test.go
+++ b/queue_test.go
@@ -15,7 +15,7 @@ func TestPriorityQueue(t *testing.T) {
 
 	pq := NewPriorityQueue()
 	for _, priority := range items {
-		pq.Push(&Item{priority: priority})
+		pq.Push(&Task{At: priority})
 	}
 
 	t.Run("Len", func(t *testing.T) {
@@ -35,27 +35,27 @@ func TestPriorityQueue(t *testing.T) {
 
 	t.Run("Swap", func(t *testing.T) {
 		pq.queue.Swap(0, 1)
-		if pq.queue[0].priority != items[1] {
-			t.Errorf("pq[0].priority = %v, want %v", pq.queue[0].priority, items[1])
+		if pq.queue[0].At != items[1] {
+			t.Errorf("pq[0].priority = %v, want %v", pq.queue[0].At, items[1])
 		}
-		if pq.queue[1].priority != items[0] {
-			t.Errorf("pq[1].priority = %v, want %v", pq.queue[1].priority, items[0])
+		if pq.queue[1].At != items[0] {
+			t.Errorf("pq[1].priority = %v, want %v", pq.queue[1].At, items[0])
 		}
 	})
 
-	newItem := &Item{priority: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
+	newItem := &Task{At: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
 	t.Run("Push", func(t *testing.T) {
 		pq.Push(newItem)
-		if pq.Peek().priority != newItem.priority {
-			t.Errorf("pq.Peek() = %v, want %v", pq.Peek().priority.String(), newItem.priority.String())
+		if pq.Peek().At != newItem.At {
+			t.Errorf("pq.Peek() = %v, want %v", pq.Peek().At.String(), newItem.At.String())
 		}
 	})
 
 	t.Run("Pop", func(t *testing.T) {
 		l := pq.Len()
 		item := pq.Pop()
-		if item.priority != newItem.priority {
-			t.Errorf("item.priority = %v, want %v", item.priority, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		if item.At != newItem.At {
+			t.Errorf("item.priority = %v, want %v", item.At, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 		}
 		if pq.Len() != l-1 {
 			t.Errorf("pq.Len() = %d, want %d", pq.Len(), 3)
@@ -65,8 +65,8 @@ func TestPriorityQueue(t *testing.T) {
 	t.Run("Peek", func(t *testing.T) {
 		l := pq.Len()
 		item := pq.Peek()
-		if item.priority != pq.queue[0].priority {
-			t.Errorf("item.priority = %v, want %v", item.priority, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		if item.At != pq.queue[0].At {
+			t.Errorf("item.priority = %v, want %v", item.At, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
 		}
 		if pq.Len() != l {
 			t.Errorf("pq.Len() = %d, want %d", pq.Len(), 3)
@@ -75,14 +75,14 @@ func TestPriorityQueue(t *testing.T) {
 
 	t.Run("Pop All", func(t *testing.T) {
 		for _, i := range items {
-			pq.Push(&Item{priority: i})
+			pq.Push(&Task{At: i})
 		}
 
-		previousTime := pq.Peek().priority
+		previousTime := pq.Peek().At
 		for pq.Len() > 0 {
 			item := pq.Pop()
-			if item.priority.Before(previousTime) {
-				t.Errorf("item.priority = %v, want after or equal to %v", item.priority, previousTime)
+			if item.At.Before(previousTime) {
+				t.Errorf("item.priority = %v, want after or equal to %v", item.At, previousTime)
 			}
 		}
 	})

--- a/queue_test.go
+++ b/queue_test.go
@@ -13,9 +13,9 @@ func TestPriorityQueue(t *testing.T) {
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 
-	pq := make(PriorityQueue, len(items))
-	for i, priority := range items {
-		pq[i] = &Item{priority: priority}
+	pq := NewPriorityQueue()
+	for _, priority := range items {
+		pq.Push(&Item{priority: priority})
 	}
 
 	t.Run("Len", func(t *testing.T) {
@@ -25,27 +25,27 @@ func TestPriorityQueue(t *testing.T) {
 	})
 
 	t.Run("Less", func(t *testing.T) {
-		if pq.Less(0, 1) {
+		if pq.queue.Less(0, 1) {
 			t.Errorf("pq.Less(0, 1) = true, want false")
 		}
-		if !pq.Less(1, 2) {
+		if !pq.queue.Less(1, 2) {
 			t.Errorf("pq.Less(1, 2) = false, want true")
 		}
 	})
 
 	t.Run("Swap", func(t *testing.T) {
-		pq.Swap(0, 1)
-		if pq[0].priority != items[1] {
-			t.Errorf("pq[0].priority = %v, want %v", pq[0].priority, items[1])
+		pq.queue.Swap(0, 1)
+		if pq.queue[0].priority != items[1] {
+			t.Errorf("pq[0].priority = %v, want %v", pq.queue[0].priority, items[1])
 		}
-		if pq[1].priority != items[0] {
-			t.Errorf("pq[1].priority = %v, want %v", pq[1].priority, items[0])
+		if pq.queue[1].priority != items[0] {
+			t.Errorf("pq[1].priority = %v, want %v", pq.queue[1].priority, items[0])
 		}
 	})
 
 	newItem := &Item{priority: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
 	t.Run("Push", func(t *testing.T) {
-		pq.PushItem(newItem)
+		pq.Push(newItem)
 		if pq.Peek().priority != newItem.priority {
 			t.Errorf("pq.Peek() = %v, want %v", pq.Peek().priority.String(), newItem.priority.String())
 		}
@@ -53,7 +53,7 @@ func TestPriorityQueue(t *testing.T) {
 
 	t.Run("Pop", func(t *testing.T) {
 		l := pq.Len()
-		item := pq.PopItem()
+		item := pq.Pop()
 		if item.priority != newItem.priority {
 			t.Errorf("item.priority = %v, want %v", item.priority, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 		}
@@ -65,7 +65,7 @@ func TestPriorityQueue(t *testing.T) {
 	t.Run("Peek", func(t *testing.T) {
 		l := pq.Len()
 		item := pq.Peek()
-		if item.priority != pq[0].priority {
+		if item.priority != pq.queue[0].priority {
 			t.Errorf("item.priority = %v, want %v", item.priority, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
 		}
 		if pq.Len() != l {
@@ -75,12 +75,12 @@ func TestPriorityQueue(t *testing.T) {
 
 	t.Run("Pop All", func(t *testing.T) {
 		for _, i := range items {
-			pq.PushItem(&Item{priority: i})
+			pq.Push(&Item{priority: i})
 		}
 
 		previousTime := pq.Peek().priority
 		for pq.Len() > 0 {
-			item := pq.PopItem()
+			item := pq.Pop()
 			if item.priority.Before(previousTime) {
 				t.Errorf("item.priority = %v, want after or equal to %v", item.priority, previousTime)
 			}

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,89 @@
+package scheduledworker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	items := []time.Time{
+		time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	pq := make(PriorityQueue, len(items))
+	for i, priority := range items {
+		pq[i] = &Item{priority: priority}
+	}
+
+	t.Run("Len", func(t *testing.T) {
+		if pq.Len() != len(items) {
+			t.Errorf("pq.Len() = %d, want %d", pq.Len(), len(items))
+		}
+	})
+
+	t.Run("Less", func(t *testing.T) {
+		if pq.Less(0, 1) {
+			t.Errorf("pq.Less(0, 1) = true, want false")
+		}
+		if !pq.Less(1, 2) {
+			t.Errorf("pq.Less(1, 2) = false, want true")
+		}
+	})
+
+	t.Run("Swap", func(t *testing.T) {
+		pq.Swap(0, 1)
+		if pq[0].priority != items[1] {
+			t.Errorf("pq[0].priority = %v, want %v", pq[0].priority, items[1])
+		}
+		if pq[1].priority != items[0] {
+			t.Errorf("pq[1].priority = %v, want %v", pq[1].priority, items[0])
+		}
+	})
+
+	newItem := &Item{priority: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
+	t.Run("Push", func(t *testing.T) {
+		pq.PushItem(newItem)
+		if pq.Peek().priority != newItem.priority {
+			t.Errorf("pq.Peek() = %v, want %v", pq.Peek().priority.String(), newItem.priority.String())
+		}
+	})
+
+	t.Run("Pop", func(t *testing.T) {
+		l := pq.Len()
+		item := pq.PopItem()
+		if item.priority != newItem.priority {
+			t.Errorf("item.priority = %v, want %v", item.priority, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		}
+		if pq.Len() != l-1 {
+			t.Errorf("pq.Len() = %d, want %d", pq.Len(), 3)
+		}
+	})
+
+	t.Run("Peek", func(t *testing.T) {
+		l := pq.Len()
+		item := pq.Peek()
+		if item.priority != pq[0].priority {
+			t.Errorf("item.priority = %v, want %v", item.priority, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		}
+		if pq.Len() != l {
+			t.Errorf("pq.Len() = %d, want %d", pq.Len(), 3)
+		}
+	})
+
+	t.Run("Pop All", func(t *testing.T) {
+		for _, i := range items {
+			pq.PushItem(&Item{priority: i})
+		}
+
+		previousTime := pq.Peek().priority
+		for pq.Len() > 0 {
+			item := pq.PopItem()
+			if item.priority.Before(previousTime) {
+				t.Errorf("item.priority = %v, want after or equal to %v", item.priority, previousTime)
+			}
+		}
+	})
+}

--- a/scheduledworker.go
+++ b/scheduledworker.go
@@ -105,7 +105,7 @@ func (w *worker) insertTask(task Task) {
 	w.Lock()
 	defer w.Unlock()
 
-	w.queue.Push(&Item{
+	w.queue.PushItem(&Item{
 		task:     task,
 		priority: task.At,
 	})
@@ -117,7 +117,7 @@ func (w *worker) getTasks() []Task {
 	defer w.Unlock()
 
 	for w.queue.Peek() != nil && time.Now().After(w.queue.Peek().priority) {
-		item := w.queue.Pop().(*Item)
+		item := w.queue.PopItem()
 		if item == nil {
 			break
 		}

--- a/scheduledworker.go
+++ b/scheduledworker.go
@@ -124,7 +124,8 @@ func (w *worker) getTasks() []*Task {
 	w.Lock()
 	defer w.Unlock()
 
-	for w.queue.Peek() != nil && time.Now().After(w.queue.Peek().At) {
+	currentTime := time.Now()
+	for w.queue.Peek() != nil && currentTime.After(w.queue.Peek().At) {
 		task := w.queue.Pop()
 		if task == nil {
 			break

--- a/scheduledworker_test.go
+++ b/scheduledworker_test.go
@@ -2,47 +2,58 @@ package scheduledworker
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 func TestScheduledWorker(t *testing.T) {
-	scheduler := New().SetDuration(time.Microsecond).Start()
-	scheduler.Start()
+	scheduler := New().
+		SetDuration(time.Microsecond).
+		SetMaxWorker(1).
+		Start()
 
-	workDone := 0
-	mu := sync.Mutex{}
+	var wg sync.WaitGroup
+	wg.Add(3)
+	counter := int64(0)
 
 	scheduler.Submit(Task{
 		At: time.Now().Add(time.Microsecond),
 		Fn: func() {
-			mu.Lock()
-			workDone++
-			mu.Unlock()
+			if atomic.LoadInt64(&counter) != 0 {
+				t.Errorf("counter should be 0")
+			}
+			atomic.AddInt64(&counter, 1)
+			wg.Done()
 		},
 	})
 
 	scheduler.Submit(Task{
 		At: time.Now().Add(time.Microsecond * 20),
 		Fn: func() {
-			mu.Lock()
-			workDone++
-			mu.Unlock()
+			if atomic.LoadInt64(&counter) != 1 {
+				t.Errorf("counter should be 1")
+			}
+			atomic.AddInt64(&counter, 1)
+			wg.Done()
 		},
 	})
 
 	scheduler.Submit(Task{
-		At: time.Now().Add(time.Microsecond * 40),
+		At: time.Now().Add(time.Microsecond * 50),
 		Fn: func() {
-			mu.Lock()
-			workDone++
-			mu.Unlock()
+			if atomic.LoadInt64(&counter) != 2 {
+				t.Errorf("counter should be 2")
+			}
+			atomic.AddInt64(&counter, 1)
+			wg.Done()
 		},
 	})
+	wg.Wait()
 
 	scheduler.Stop()
-	if workDone != 3 {
-		t.Errorf("expected: %d, got: %d", 3, workDone)
+	if counter != 3 {
+		t.Errorf("expected: %d, got: %d", 3, counter)
 	}
 }
 


### PR DESCRIPTION
This PR replaces the Array-based implement with a Task queue. The queue is modifiable and by default, a time-based priority queue is used if no queue is provided.

- To provide a queue simply do a `scheduler.SetQueue(queue)`.
- The `queue` needs to implement a `Queue` interface, check the `queue.go` file for the definition.